### PR TITLE
Change lib import

### DIFF
--- a/demo/package.json
+++ b/demo/package.json
@@ -8,7 +8,7 @@
     "eject": "expo eject"
   },
   "dependencies": {
-    "@rootstrap/react-native-use-animate": "^0.1.2",
+    "@rootstrap/react-native-use-animate": "../",
     "expo": "~37.0.3",
     "react": "~16.9.0",
     "react-dom": "~16.9.0",

--- a/demo/yarn.lock
+++ b/demo/yarn.lock
@@ -1140,7 +1140,7 @@
     ws "^1.1.0"
 
 "@rootstrap/react-native-use-animate@../":
-  version "0.1.0"
+  version "0.1.2"
 
 "@types/color-name@^1.1.1":
   version "1.1.1"

--- a/demo/yarn.lock
+++ b/demo/yarn.lock
@@ -1139,10 +1139,8 @@
     wcwidth "^1.0.1"
     ws "^1.1.0"
 
-"@rootstrap/react-native-use-animate@^0.1.2":
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/@rootstrap/react-native-use-animate/-/react-native-use-animate-0.1.2.tgz#fb635e3feb2ddb61d91daff3aa6123609e9b324d"
-  integrity sha512-s2xTLiKNN7MrPLZFibC80Q2caBKRhns/zQV66Z2HB8g84fzUCyc5WXhSDkwJENx7fI9EozWTDxtzg5yJi5FdHg==
+"@rootstrap/react-native-use-animate@../":
+  version "0.1.0"
 
 "@types/color-name@^1.1.1":
   version "1.1.1"


### PR DESCRIPTION
This PR changes how the library is imported in the demo project.

It is now imported locally which means that:

node modules for the library need to be installed in production mode when testing so there is no conflict with double react native installations

when new changes are made to the library and the developer wants to see them reflected in the demo they need to run `yarn install --force` to update the library installation.

This was the fastest way to test the changes locally that we found, this process can evolve in the future and it will be better explained once we add a how to contribute section to the readme.