### PR TITLE
Allow user to fully customise the interpolate function

### DIFF
--- a/src/useAnimate.js
+++ b/src/useAnimate.js
@@ -66,10 +66,11 @@ const useAnimate = ({
   const sequenceAnimation = Animated.sequence(sequence);
 
   const interpolate = useCallback(
-    ({ inputRange, outputRange }) =>
+    ({ inputRange, outputRange, ...config }) =>
       animatedValue.interpolate({
         inputRange: inputRange || [fromValue, toValue],
-        outputRange,
+        outputRange: outputRange || [fromValue, toValue],
+        ...config,
       }),
     [animatedValue, fromValue, toValue],
   );


### PR DESCRIPTION
### Issue:

The interpolate method was ignoring some of the possible params.

#### Description:

None of the config params should be ignored by the interpolate method. 
These configurations were being ignored:
        easing?: (input: number) => number;
        extrapolate?: ExtrapolateType;
        extrapolateLeft?: ExtrapolateType;
        extrapolateRight?: ExtrapolateType;

---

#### Documentation:

> Mark with [x] if it corresponds

- [ ] Docs have been updated
- [ ] The change is being reflected in the demo app
- [x] There's no need to document this.

#### Tested on:

- [x] iOS
- [x] Android

#### Notes:

\*

---

#### Preview:
