### PR TITLE
Fix/allow triggered animations to bounce

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rootstrap/react-native-use-animate",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "React Native animations made simple",
   "main": "lib/index.js",
   "module": "src/index.js",

--- a/src/useAnimate.js
+++ b/src/useAnimate.js
@@ -3,26 +3,28 @@ import { Animated } from 'react-native';
 
 /**
  * @function useAnimate
- * @param {number} fromValue - The value from which the animation will start
- * @param {number} toValue - The value to which the animation should end
- * @param {boolean} bounce - True if the animation should return to its initial state
+ * @param {number} fromValue - The value from which the animation will start.
+ * @param {number} toValue - The value to which the animation should end.
+ * @param {boolean} bounce - True if the animation should return to its initial state.
  * @param {number} iterations - The amount of times the animation should run,
- * -1 if you want to be an infinite loop
+ * -1 if you want to be an infinite loop.
  * @param {number} duration - The time it takes the value to go from fromValue to toValue
- *  (or back to its initial state if bounce is true)
+ *  (or back to its initial state if bounce is true).
  * @param {number} delay - The number of miliseconds that it should pass before start animating
  * @param {function} easing - The `Easing` module has tons of pre-defined
- * curves, or you can use your own function
+ * curves, or you can use your own function.
  * @param {string} useNativeDriver - useNativeDriver - check Animated API for reference
  * @param {boolean} animate - false if this animation is being used inside a parallel
- *  or sequence animation
+ *  or sequence animation.
  * @param {function} callback - The method it should call after the animation has
  *  ended (in case animate is false then this won't be executed,
- * it should be passed as part of the Parallel's or sequence's callback)
+ * it should be passed as part of the Parallel's or sequence's callback).
  * @param {ref} referenceValue - In case you want to reuse an animated value you
- * can pass it as referenceValue
+ * can pass it as referenceValue.
  * @param {boolean} isInteraction - Whether or not this animation creates an
  * "interaction handle" on the InteractionManager. Default true.
+ * @param {boolean} shouldReset - Whether or not the animation should reset when the values change.
+ * Useful for animations that bounce but are trigger dependent (set to false).
  */
 const useAnimate = ({
   fromValue = 0,
@@ -37,6 +39,7 @@ const useAnimate = ({
   callback,
   referenceValue,
   isInteraction = true,
+  shouldReset = true,
 }) => {
   const animatedValue =
     referenceValue || useRef(new Animated.Value(fromValue)).current;
@@ -68,8 +71,11 @@ const useAnimate = ({
   const interpolate = useCallback(
     ({ inputRange, outputRange, ...config }) =>
       animatedValue.interpolate({
-        inputRange: inputRange || [fromValue, toValue],
-        outputRange: outputRange || [fromValue, toValue],
+        inputRange: inputRange || [
+          Math.min(fromValue, toValue),
+          Math.max(fromValue, toValue),
+        ],
+        outputRange,
         ...config,
       }),
     [animatedValue, fromValue, toValue],
@@ -86,7 +92,7 @@ const useAnimate = ({
 
   const startAnimating = useCallback(
     (nextAnimation) => {
-      animation.reset();
+      shouldReset && animation.reset();
 
       const callbackAnimation = () => {
         callback && callback({ animation, animatedValue });
@@ -101,12 +107,12 @@ const useAnimate = ({
         animation.start(callbackAnimation);
       }
     },
-    [animation, callback],
+    [animatedValue, animation, callback, delay, shouldReset],
   );
 
   useEffect(() => {
     animate && startAnimating();
-  }, [fromValue, toValue, bounce, duration, animate, startAnimating, reset]);
+  }, [animate, startAnimating]);
 
   return { interpolate, animatedValue, startAnimating, reset };
 };


### PR DESCRIPTION
#### Description:

This PR adds a flag that lets you turn off animation reset before each new animation starts. I found this useful when animating a floating label for an input.

It also rearranges some hook dependencies so now they are more correct. All animations seem to be working as before as well as the label I mentioned before.

---

#### Documentation:

> Mark with [x] if it corresponds

- [x] Docs have been updated
- [ ] The change is being reflected in the demo app
	|_ Not yet, I think we should figure out a way to display a broader range of animations because only two is very limited to showcase all the range of options. But that would come in another PR

#### Tested on:

- [x] iOS
- [x] Android
